### PR TITLE
Makefile: MACHINE->DEVKIT to fix toolchain compile failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ srcdir := $(srcdir:/=)
 confdir := $(srcdir)/conf
 wrkdir := $(CURDIR)/work
 
-MACHINE ?= mpfs
-device_tree := $(confdir)/$(MACHINE).dts
+# target mpfs by default
+DEVKIT ?= mpfs
+device_tree := $(confdir)/$(DEVKIT).dts
 device_tree_blob := $(wrkdir)/riscvpc.dtb
 
 uboot_srcdir := $(srcdir)/HiFive_U-Boot
@@ -42,7 +43,7 @@ buildroot_rootfs_config := $(confdir)/buildroot_rootfs_config
 
 linux_srcdir := $(srcdir)/linux
 linux_wrkdir := $(wrkdir)/linux
-linux_defconfig := $(confdir)/$(MACHINE)_linux_defconfig
+linux_defconfig := $(confdir)/$(DEVKIT)_linux_defconfig
 
 vmlinux := $(linux_wrkdir)/vmlinux
 vmlinux_stripped := $(linux_wrkdir)/vmlinux-stripped

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ This will take some time and require around 7GB of disk space. Some modules may 
 
 Once the submodules are initialized, run `make` and the complete toolchain and bbl image will be built.   
 The completed build tree will consume about 14G of disk space.      
-You can choose between LC-MPFS-DEV-KIT and MPFS-DEV-KIT by setting the `MACHINE` variable.
+You can choose between LC-MPFS-DEV-KIT and MPFS-DEV-KIT by setting the `DEVKIT` variable.
 ```bash
-make MACHINE=mpfs
+make DEVKIT=mpfs
 # or
-make MACHINE=lc-mpfs
+make DEVKIT=lc-mpfs
 ```
 By default `mpfs` will be used.
 

--- a/doc/LC-MPFS-DEV-KIT_user_guide.md
+++ b/doc/LC-MPFS-DEV-KIT_user_guide.md
@@ -147,12 +147,12 @@ $ cd mpfs-linux-sdk
 $ git checkout master
 $ git submodule update --init --recursive
 $ unset RISCV
-$ make all MACHINE=lc-mpfs
+$ make all DEVKIT=lc-mpfs
 ```
 Note: The first time the build is run it can take a long time, as it also builds the RISC-V cross compiler toolchain. 
 
 The output file `work/bbl.bin` contains the bootloader (RISC-V pk/bbl), the Linux kernel, and the device tree blob. A GPT image is also created, with U-Boot as the first stage boot loader that can be copied to an SD card. 
-The option `MACHINE=mpfs` selects the correct device tree for the board.   
+The option `DEVKIT=lc-mpfs` selects the correct device tree for the board.   
 
 ### Preparing an SD Card and Programming an Image for the First Time
 Add an SD card to boot your system (16 GB or 32 GB). If the SD card is auto-mounted, first unmount it manually.               
@@ -205,7 +205,7 @@ sudo make DISK=/dev/sdX format-boot-loader
 To change the machine being targeted, type the following from the top level of mpfs-linux-sdk:
 ```
 $ rm -rf work/linux/ work/riscvpc.dtb
-$ make MACHINE=lc-mpfs
+$ make DEVKIT=lc-mpfs
 ```
 Copy this newly built image to the SD card using the same method as before:
 ```

--- a/doc/LC-MPFS-DEV-KIT_user_guide.md
+++ b/doc/LC-MPFS-DEV-KIT_user_guide.md
@@ -210,6 +210,7 @@ $ make DEVKIT=lc-mpfs
 Copy this newly built image to the SD card using the same method as before:
 ```
 sudo make DISK=/dev/sdX format-boot-loader
+```
 
 The source for the device tree for HiFive Unleashed Expansion board is in `conf/lc-mpfs.dts`.           
 The configuration options used for the Linux kernel are in `conf/linux_defconfig`.

--- a/doc/MPFS-DEV-KIT_user_guide.md
+++ b/doc/MPFS-DEV-KIT_user_guide.md
@@ -252,12 +252,12 @@ $ cd mpfs-linux-sdk
 $ git checkout master
 $ git submodule update --init --recursive
 $ unset RISCV
-$ make all MACHINE=mpfs
+$ make all DEVKIT=mpfs
 ```
 Note: The first time the build is run it can take a long time, as it also builds the RISC-V cross compiler toolchain. 
 
 The output file `work/bbl.bin` contains the bootloader (RISC-V pk/bbl), the Linux kernel, and the device tree blob. A GPT image is also created, with U-Boot as the first stage boot loader that can be copied to an SD card. 
-The option `MACHINE=mpfs` selects the correct device tree for the board.         
+The option `DEVKIT=mpfs` selects the correct device tree for the board.         
 
 #### Preparing an SD Card and Programming an Image for the First Time
 Add an SD card to boot your system (16 GB or 32 GB). If the SD card is auto-mounted, first unmount it manually.               
@@ -317,7 +317,7 @@ sudo make DISK=/dev/sdX format-boot-loader
 To change the machine being targeted, type the following from the top level of mpfs-linux-sdk:
 ```
 $ rm -rf work/linux/ work/riscvpc.dtb 
-$ make MACHINE=mpfs
+$ make DEVKIT=mpfs
 ```
 Copy this newly built image to the SD card using the same method as before:
 ```


### PR DESCRIPTION
Using `MACHINE` to change the target board was causing the toolchain build to fail. Switched to using `DEVKIT` instead.